### PR TITLE
improvements and code cleanup in GFX helper

### DIFF
--- a/examples/example7_gfx_helpers.rb
+++ b/examples/example7_gfx_helpers.rb
@@ -19,11 +19,26 @@ class Game < Chingu::Window
     push_game_state(FillGradient)
     push_game_state(FillGradientRect)
     push_game_state(FillGradientMultipleColors)
+    push_game_state(DrawCircle)
     push_game_state(Particles)
   end
   
   def next_effect
     pop_game_state
+  end
+end
+
+class DrawCircle < Chingu::GameState
+  def draw
+    $window.caption = "circles and arcs (space to continue)"
+    draw_circle(0, 0, 300, Color::RED)
+    fill_circle($window.width, $window.height, 200, Color::RED)
+    
+    colors = [Color::RED, Color::YELLOW, Color::GREEN, Color::BLUE]
+    0.step(360, 90).each_cons(2).zip(colors).each do |(a1, a2), color|
+      fill_arc(400, 100, 100, a1, a2, color)
+    end
+    
   end
 end
 

--- a/lib/chingu/helpers/gfx.rb
+++ b/lib/chingu/helpers/gfx.rb
@@ -27,7 +27,9 @@ module Chingu
   # All drawings depend on the global variable $window which should be an instance of Gosu::Window or Chingu::Window
   #
   module GFX
-  
+    
+    CIRCLE_STEP = 10
+    
     #
     # Fills whole window with specified 'color' and 'zorder'
     #
@@ -68,17 +70,6 @@ module Chingu
       _stroke_rect(rect, color, color, color, color, zorder, mode)
     end
     
-    
-    #
-    # Draws an unfilled circle, thanks shawn24!
-    #
-    CIRCLE_STEP = 10
-    def draw_circle(cx,cy,r,color)      
-      0.step(360, CIRCLE_STEP) do |a1|
-        a2 = a1 + CIRCLE_STEP
-        $window.draw_line cx + Gosu.offset_x(a1, r), cy + Gosu.offset_y(a1, r), color, cx + Gosu.offset_x(a2, r), cy + Gosu.offset_y(a2, r), color, 9999
-      end
-    end
     
     #
     # Fills a given Rect 'rect' with Color 'color', drawing with zorder 'zorder'
@@ -129,6 +120,23 @@ module Chingu
       
     end
     
+    #
+    # Draws an unfilled circle, thanks shawn24!
+    #
+    def draw_circle(cx, cy, r, color, zorder = 0, mode = :default)
+      draw_arc(cx, cy, r, 0, 360, color, zorder, mode)
+    end
+    
+    #
+    # Draws an unfilled arc from a1 to a2
+    #
+    def draw_arc(cx, cy, r, from, to, color, zorder = 0, mode = :default)
+      from, to = to, from if from > to
+      from.step(to, CIRCLE_STEP).each_cons(2) do |a1, a2|
+        _draw_arc_strip(cx, cy, r, a1, a2, color, zorder, mode)
+      end
+    end
+    
     private
     
     def _fill_rect(rect, color_a, color_b, color_c, color_d, zorder, mode)
@@ -148,6 +156,16 @@ module Chingu
       $window.draw_line(left,  bottom, color_b, right, bottom, color_c, zorder, mode)
       $window.draw_line(right, bottom, color_c, right, top,    color_d, zorder, mode)
       $window.draw_line(right, top,    color_d, left,  top,    color_a, zorder, mode)
+    end
+    
+    def _draw_arc_strip(cx, cy, r, a1, a2, color, zorder = 0, mode = :default)
+      $window.translate(cx, cy) do
+        x1, y1 = Gosu.offset_x(a1, r), Gosu.offset_y(a1, r)
+        x2, y2 = Gosu.offset_x(a2, r), Gosu.offset_y(a2, r)
+        $window.draw_line(x1, y1, color,
+                          x2, y2, color,
+                          zorder, mode)
+      end
     end
     
   end

--- a/lib/chingu/helpers/gfx.rb
+++ b/lib/chingu/helpers/gfx.rb
@@ -137,6 +137,23 @@ module Chingu
       end
     end
     
+    #
+    # Draws a filled circle
+    #
+    def fill_circle(cx, cy, r, color, zorder = 0, mode = :default)
+      fill_arc(cx, cy, r, 0, 360, color, zorder, mode)
+    end
+    
+    #
+    # Draws a filled arc from a1 to a2
+    #
+    def fill_arc(cx, cy, r, from, to, color, zorder = 0, mode = :default)
+      from, to = to, from if from > to
+      from.step(to, CIRCLE_STEP).each_cons(2) do |a1, a2|
+        _fill_arc_strip(cx, cy, r, a1, a2, color, zorder, mode)
+      end
+    end
+    
     private
     
     def _fill_rect(rect, color_a, color_b, color_c, color_d, zorder, mode)
@@ -165,6 +182,17 @@ module Chingu
         $window.draw_line(x1, y1, color,
                           x2, y2, color,
                           zorder, mode)
+      end
+    end
+    
+    def _fill_arc_strip(cx, cy, r, a1, a2, color, zorder = 0, mode = :default)
+      $window.translate(cx, cy) do
+        x1, y1 = Gosu.offset_x(a1, r), Gosu.offset_y(a1, r)
+        x2, y2 = Gosu.offset_x(a2, r), Gosu.offset_y(a2, r)
+        $window.draw_triangle(0,  0,  color,
+                              x1, y1, color,
+                              x2, y2, color,
+                              zorder, mode)
       end
     end
     


### PR DESCRIPTION
Mostly, I cleaned up the GFX helper a little to reduce the amount of duplicated code. I think more can be done here but it's a good start!

Also, and most excitingly, I've changed the circle drawing algorithm to a much more awesome and efficient one by SiegeLord. Only two calls to `cos` and `sin` in the whole thing! I've also added support for drawing arcs, filled and unfilled, using the same code. Support for ellipses could also be added using Gosu's `Window#scale` but I didn't feel like tackling that problem since it probably wouldn't be that useful to most people.
