### PR TITLE
reducing the amount of written code for helpers that delegate methods to other objects

### DIFF
--- a/lib/chingu/console.rb
+++ b/lib/chingu/console.rb
@@ -25,6 +25,7 @@ module Chingu
   #
   #
   class Console
+    include Chingu::Helpers::FPSCounter         # Adds FPSCounter delegators
     include Chingu::Helpers::GameState          # Easy access to the global game state-queue
     include Chingu::Helpers::GameObject         # Adds game_objects_of_class etc ...
     
@@ -73,28 +74,6 @@ module Chingu
       game_state_manager.inside_state || game_state_manager.current_game_state || self
     end
     
-    #
-    # Frames per second, access with $window.fps or $window.framerate
-    #
-    def fps
-      @fps_counter.fps
-    end
-    alias :framerate :fps
-
-    #
-    # Total amount of game iterations (ticks)
-    #
-    def ticks
-      @fps_counter.ticks
-    end
-    
-    #
-    # Mathematical short name for "milliseconds since last tick"
-    #
-    def dt
-      @milliseconds_since_last_tick
-    end
-
     #
     # Chingus core-logic / loop. Gosu will call this each game-iteration.
     #

--- a/lib/chingu/fpscounter.rb
+++ b/lib/chingu/fpscounter.rb
@@ -26,7 +26,19 @@ module Chingu
   # register_tick() must be called every game loop iteration
   #
 	class FPSCounter
-		attr_reader :fps, :milliseconds_since_last_tick, :ticks
+    attr_reader :milliseconds_since_last_tick
+    alias :dt :milliseconds_since_last_tick
+    
+    #
+    # Frames per second, access with $window.fps or $window.framerate
+    #
+    attr_reader :fps
+    alias :framerate :fps
+    
+    #
+    # Total amount of game iterations (ticks)
+    #
+    attr_reader :ticks
   
 		def initialize
 			@current_second = Gosu::milliseconds / 1000

--- a/lib/chingu/game_object_list.rb
+++ b/lib/chingu/game_object_list.rb
@@ -19,6 +19,7 @@
 #
 #++
 
+require 'forwardable'
 
 module Chingu
   #
@@ -26,6 +27,8 @@ module Chingu
   # An instance of GameObjectList is automaticly created as "game_objects" if using Chingu::Window
   #
   class GameObjectList
+    extend Forwardable
+    
     attr_reader :visible_game_objects, :unpaused_game_objects
         
     def initialize(options = {})
@@ -37,6 +40,11 @@ module Chingu
       #@visible_game_objects = {}
       #@unpaused_game_objects = {}
     end
+    
+    def_delegator :@game_objects, :size
+    def_delegator :@game_objects, :empty?
+    def_delegator :@game_objects, :first
+    def_delegator :@game_objects, :last
     
     def to_s
       "#{@game_objects.size} game objects."
@@ -85,14 +93,6 @@ module Chingu
       @game_objects.select { |object| object.destroy if yield(object) }
     end
     
-    def size
-      @game_objects.size
-    end
-    
-    def empty?
-      @game_objects.empty?
-    end
-
     def update
       @unpaused_game_objects.each { |go| go.update_trait; go.update; }
     end
@@ -129,14 +129,6 @@ module Chingu
 
     def map
       @game_objects.map { |object| yield object }
-    end
-
-    def first
-      @game_objects.first
-    end
-
-    def last
-      @game_objects.last
     end
 
     #

--- a/lib/chingu/helpers/fps_counter.rb
+++ b/lib/chingu/helpers/fps_counter.rb
@@ -1,0 +1,39 @@
+#--
+#
+# Chingu -- OpenGL accelerated 2D game framework for Ruby
+# Copyright (C) 2009 ippa / ippa@rubylicio.us
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#
+#++
+
+require 'forwardable'
+
+module Chingu
+  module Helpers
+  
+    #
+    # Convenience-methods for classes that have an FPS counter
+    # Mixed into Chingu::Window and Chingu::Console
+    #
+    module FPSCounter
+      extend Forwardable
+      def_delegator  :@fps_counter, :ticks
+      def_delegators :@fps_counter, :fps, :framerate # TODO: switch to Gosu::fps
+      def_delegators :@fps_counter, :dt, :milliseconds_since_last_tick
+    end
+  
+  end
+end

--- a/lib/chingu/helpers/game_object.rb
+++ b/lib/chingu/helpers/game_object.rb
@@ -19,6 +19,8 @@
 #
 #++
 
+require 'forwardable'
+
 module Chingu
   module Helpers
   
@@ -27,32 +29,16 @@ module Chingu
   # Mixed into Chingu::Window and Chingu::GameState
   #
   module GameObject
-  
-    def add_game_object(object)
-      @game_objects.add_game_object(object)
-    end
+    extend Forwardable
     
-    def remove_game_object(object)
-      @game_objects.remove_game_object(object)
-    end
+    attr_reader :game_objects
     
-    def game_objects
-      @game_objects
-    end
-    
-    def show_game_object(object)
-      @game_objects.show_game_object(object)
-    end    
-    def hide_game_object(object)
-      @game_objects.hide_game_object(object)
-    end
-    def pause_game_object(object)
-      @game_objects.pause_game_object(object)
-    end
-    def unpause_game_object(object)
-      @game_objects.unpause_game_object(object)
-    end 
-    
+    def_delegator :@game_objects, :add_game_object
+    def_delegator :@game_objects, :remove_game_object
+    def_delegator :@game_objects, :show_game_object
+    def_delegator :@game_objects, :hide_game_object
+    def_delegator :@game_objects, :pause_game_object
+    def_delegator :@game_objects, :unpause_game_object
     
     #
     # Fetch game objects of a certain type/class

--- a/lib/chingu/helpers/game_state.rb
+++ b/lib/chingu/helpers/game_state.rb
@@ -19,6 +19,7 @@
 #
 #++
 
+require 'forwardable'
 
 module Chingu
   module Helpers
@@ -29,33 +30,14 @@ module Chingu
   # It will make call new() on a class, and just push an object.
   #
   module GameState
-    def game_states
-      game_state_manager.game_states
-    end
-    
-    def push_game_state(state, options = {})
-      game_state_manager.push_game_state(state, options)
-    end
-  
-    def pop_game_state(options = {})
-      game_state_manager.pop_game_state(options)
-    end
-
-    def switch_game_state(state, options = {})
-      game_state_manager.switch_game_state(state, options)
-    end
-
-    def transitional_game_state(state, options = {})
-      game_state_manager.transitional_game_state(state, options)
-    end
-
-    def current_game_state
-      game_state_manager.current_game_state
-    end
-    
-    def clear_game_states
-      game_state_manager.clear_game_states
-    end
+    extend Forwardable
+    def_delegator :game_state_manager, :game_states
+    def_delegator :game_state_manager, :push_game_state
+    def_delegator :game_state_manager, :pop_game_state
+    def_delegator :game_state_manager, :switch_game_state
+    def_delegator :game_state_manager, :transitional_game_state
+    def_delegator :game_state_manager, :current_game_state
+    def_delegator :game_state_manager, :clear_game_states
   end
   
   end

--- a/lib/chingu/window.rb
+++ b/lib/chingu/window.rb
@@ -32,6 +32,7 @@ module Chingu
   # - Tracking of button_up/button_down etc to enable Chingus pretty inputhandling
   #
   class Window < Gosu::Window
+    include Chingu::Helpers::FPSCounter         # Adds FPSCounter delegators
     include Chingu::Helpers::GFX                # Adds fill(), fade() etc to each game state
     include Chingu::Helpers::GameState          # Easy access to the global game state-queue
     include Chingu::Helpers::GameObject         # Adds game_objects_of_class etc ...
@@ -96,28 +97,6 @@ module Chingu
       game_state_manager.inside_state || game_state_manager.current_game_state || self
     end
     
-    #
-    # Frames per second, access with $window.fps or $window.framerate
-    #
-    def fps
-      @fps_counter.fps      # TODO: switch to Gosu::fps
-    end
-    alias :framerate :fps
-
-    #
-    # Total amount of game iterations (ticks)
-    #
-    def ticks
-      @fps_counter.ticks
-    end
-    
-    #
-    # Mathematical short name for "milliseconds since last tick"
-    #
-    def dt
-      @milliseconds_since_last_tick
-    end
-
     #
     # Chingus core-logic / loop. Gosu will call this each game-iteration.
     #


### PR DESCRIPTION
I've made use of Ruby's `Forwardable` module to shorten delegate methods to a single line each. Thus:

```
def add_game_object(object)
  @game_objects.add_game_object(object)
end
```

becomes

```
def_delegator :@game_objects, :add_game_object
```

Also extracted the duplicated FPS counter code from Window and Console into a new helper module.
