### PR TITLE
Quick fix for debug game state not working.

### DIFF
--- a/lib/chingu/game_states/debug.rb
+++ b/lib/chingu/game_states/debug.rb
@@ -85,7 +85,7 @@ module Chingu
         lines = text.respond_to?(:lines) ? text.lines : text
         
         lines.each_with_index do |line,i|
-          @font.draw(line, @x_offset, @y_offset + height * (i+3), Z,1,1, @text_color)
+          @font.draw(line.strip, @x_offset, @y_offset + height * (i+3), Z,1,1, @text_color)
         end       
       end
 


### PR DESCRIPTION
In example 2, the built in debug game state was not working for me at all in OS X 10.6 or Windows 7 x64, both running MRI 1.9.2.

In windows, the example did not crash, but became unresponsive. After being force quit, it dumped the following, which got me to the right area but did not shed any light on the problem. 

```
c:1118 p:---- s:4088 b:4088 l:004083 d:004087 IFUNC
c:1117 p:---- s:4086 b:4086 l:004085 d:004085 CFUNC  :lines
c:1116 p:---- s:4084 b:4084 l:004083 d:004083 CFUNC  :each_with_index
c:1115 p:0053 s:4081 b:4081 l:004080 d:004080 METHOD d:/workspace/chingu/lib/chingu/game_states/debug.rb:87
c:1114 p:0148 s:4075 b:4075 l:004074 d:004074 METHOD d:/workspace/chingu/lib/chingu/game_states/debug.rb:78
c:1113 p:0046 s:4072 b:4072 l:004071 d:004071 METHOD d:/workspace/chingu/lib/chingu/game_state_manager.rb:292
c:1112 p:0025 s:4069 b:4069 l:004068 d:004068 METHOD d:/workspace/chingu/lib/chingu/window.rb:161
c:1111 p:0031 s:4066 b:4066 l:002414 d:004065 LAMBDA d:/Ruby192/lib/ruby/gems/1.9.1/gems/gosu-0.7.33-x86-mingw32/lib/gosu/swig_patches.rb:15
c:1110 p:---- s:4062 b:4062 l:004061 d:004061 FINISH
```

The example crashed immediately when enabling the debug state in OS X, but provided a somewhat more helpful error message.

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  the argument to textWidth cannot contain line breaks
Abort trap
```

Combining the two outputs led me to find Gosu::Font#draw being called with text that contained newlines. The quick fix is to just strip text sent to this method.
