### PR TITLE
Array#each_at (for great justice)

### DIFF
--- a/lib/chingu/core_ext/array.rb
+++ b/lib/chingu/core_ext/array.rb
@@ -2,8 +2,8 @@ class Array
   
   def each_collision(*klasses)
     self.each do |object1|
-      object1.each_collision(*klasses) do |object1, object2|
-        yield object1, object2
+      object1.each_collision(*klasses) do |object, object2|
+        yield object, object2
       end
     end
   end
@@ -20,6 +20,14 @@ class Array
     self.each do |object1|
       object1.each_bounding_box_collision(*klasses) do |object1, object2|
         yield object1, object2
+      end
+    end
+  end
+
+  def each_at(x, y)
+    self.each do |object|
+      object.each_at(x, y) do |obj|
+        yield obj
       end
     end
   end


### PR DESCRIPTION
also fixed a variable "shadowing?" warning in each_collision() it was overwriting object1 in the second block, probably still happens for each_*_collision() methods. it was just a warning anyways.
Array#each_at lets you use [Class, Klass, Crass].each_at like you can with #each_collision
