### PR TITLE
allow passing an Image through Animation.new instead of only a file name.

### DIFF
--- a/lib/chingu/animation.rb
+++ b/lib/chingu/animation.rb
@@ -40,11 +40,11 @@ module Chingu
       @sub_animations = {}
       @frame_actions = []
       
-      unless image && File.exists?(file)
+      unless image || File.exists?(@file)
         Gosu::Image.autoload_dirs.each do |autoload_dir|
-          full_path = File.join(autoload_dir, file)
+          full_path = File.join(autoload_dir, @file)
           if File.exists?(full_path)
-            file = full_path
+            @file = full_path
             break
           end
         end
@@ -62,16 +62,14 @@ module Chingu
       elsif options[:size]
         @width = options[:size]
         @height = options[:size]
-      elsif file =~ /_(\d+)x(\d+)/
+      elsif @file =~ /_(\d+)x(\d+)/
         # Auto-detect width/height from filename 
         # Tilefile foo_10x25.png would mean frame width 10px and height 25px
         @width = $1.to_i
         @height = $2.to_i
       else
         # Assume the shortest side is the width/height for each frame
-        #@image = Gosu::Image.new($window, @file)
-        #@width = @height = (@image.width < @image.height) ? @image.width : @image.height
-        image ||= Gosu::Image[file]
+        image ||= Gosu::Image[@file]
         @width = @height = (image.width < image.height) ? image.width : image.height
       end
       

--- a/lib/chingu/animation.rb
+++ b/lib/chingu/animation.rb
@@ -26,11 +26,12 @@ module Chingu
     #
     def initialize(options)
       #options = {:step => 1, :loop => true, :bounce => false, :width => 32, :height => 32, :index => 0, :delay => 100}.merge(options)
-      options = {:step => 1, :loop => true, :bounce => false, :index => 0, :delay => 100}.merge(options)
+      options = {:step => 1, :loop => true, :bounce => false, :index => 0, :delay => 100, :file => nil, :image => nil}.merge(options)
       
       @loop = options[:loop]
       @bounce = options[:bounce]
       @file = options[:file]
+      image = options[:image]
       @index = options[:index]
       @delay = options[:delay]
       @step = options[:step] || 1
@@ -39,11 +40,11 @@ module Chingu
       @sub_animations = {}
       @frame_actions = []
       
-      unless File.exists?(@file)
+      unless image && File.exists?(file)
         Gosu::Image.autoload_dirs.each do |autoload_dir|
-          full_path = File.join(autoload_dir, @file)
+          full_path = File.join(autoload_dir, file)
           if File.exists?(full_path)
-            @file = full_path
+            file = full_path
             break
           end
         end
@@ -61,18 +62,20 @@ module Chingu
       elsif options[:size]
         @width = options[:size]
         @height = options[:size]
-      elsif @file =~ /_(\d+)x(\d+)/
+      elsif file =~ /_(\d+)x(\d+)/
         # Auto-detect width/height from filename 
         # Tilefile foo_10x25.png would mean frame width 10px and height 25px
         @width = $1.to_i
         @height = $2.to_i
       else
         # Assume the shortest side is the width/height for each frame
-        @image = Gosu::Image.new($window, @file)
-        @width = @height = (@image.width < @image.height) ? @image.width : @image.height
+        #@image = Gosu::Image.new($window, @file)
+        #@width = @height = (@image.width < @image.height) ? @image.width : @image.height
+        image ||= Gosu::Image[file]
+        @width = @height = (image.width < image.height) ? image.width : image.height
       end
       
-      @frames = Gosu::Image.load_tiles($window, @file, @width, @height, true)
+      @frames = Gosu::Image.load_tiles($window, image || @file, @width, @height, true)
     end
     
     #

--- a/spec/chingu/animation_spec.rb
+++ b/spec/chingu/animation_spec.rb
@@ -33,8 +33,14 @@ module Chingu
         @anim = Animation.new(:file => "images/droid_11x15.bmp")
         @anim.frames.count.should == 14
       end
+      
+      it "should load from a Gosu image" do
+        Dir.chdir(File.dirname(File.expand_path(__FILE__)))
+        @anim = Animation.new(:image => Gosu::Image["images/droid_11x15.bmp"], :size => [11, 15])
+        @anim.frames.count.should == 14
+      end
     end
-
+    
     describe "Animation loading file: droid_11x15.bmp" do
       it "should detect size and frames automatically from filename" do
         @animation.size.should == [11,15]


### PR DESCRIPTION
allow passing an Image through Animation.new instead of only a file name. 
Directly to G::Image.load_tiles, and change the lookup to use the cache. 
The default options for :image and :file might need to be checked to see if at least one is set... 
Possibly @file can be removed it isn't used anywhere in this file and it's not an accessor 
☮
