### PR TITLE
Move Chingu::VERSION into a separate file:

### DIFF
--- a/chingu.gemspec
+++ b/chingu.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.dirname(__FILE__) + '/lib/chingu'
-include Chingu
+require File.dirname(__FILE__) + '/lib/chingu/version'
 
 Gem::Specification.new do |s|
   s.name = "chingu"

--- a/lib/chingu.rb
+++ b/lib/chingu.rb
@@ -36,10 +36,9 @@ require_all "#{CHINGU_ROOT}/chingu/traits"
 require_all "#{CHINGU_ROOT}/chingu/async"
 require_all "#{CHINGU_ROOT}/chingu/async_tasks"
 require_all "#{CHINGU_ROOT}/chingu"
+require_all "#{CHINGU_ROOT}/chingu/version"
 
 module Chingu
-  VERSION = "0.9rc8"
-  
   DEBUG_COLOR = Gosu::Color.new(0xFFFF0000)
   DEBUG_ZORDER = 9999
   INFINITY = 1.0 / 0

--- a/lib/chingu/version.rb
+++ b/lib/chingu/version.rb
@@ -1,0 +1,4 @@
+module Chingu
+  VERSION = "0.9rc8"
+end
+


### PR DESCRIPTION
This makes it possible to build the gem without having Gosu installed.
