### PR TITLE
Parallax and Viewport compatibilities

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -111,8 +111,9 @@ An "@image = @animation.next" in your Player#update is usually enough to get you
 
 === Chingu::Parallax
 A class for easy parallaxscrolling. Add layers with different damping, move the camera to generate a new snapshot. See example3.rb for more.
-NOTE: Doing Parallax.create when using a trait viewport will give bad results.
-If you need parallax together with viewport do Parallax.new and then manually doing parallax.update/draw.
+NOTE: -Doing Parallax.create when using a trait viewport will give bad results.-
+-If you need parallax together with viewport do Parallax.new and then manually doing parallax.update/draw.-
+Now the Parallax.create can be used with the trait viewport. Everytime the viewport boundaries change, the Paralax.camera_x/camera_y must be updated too.
 
 === Chingu::HighScoreList
 A class to keep track of high scores, limit the list, automatic sorting on score, save/load to disc. See example13.rb for more.
@@ -757,8 +758,9 @@ This is great for scrolling games. You also have:
   viewport.lag      = 0.95              # Set a lag-factor to use in combination with x_target / y_target
   viewport.x_target = 100               # This will move viewport towards X-coordinate 100, the speed is determined by the lag-parameter.
 
-NOTE: Doing Parallax.create when using a trait viewport will give bad results.
-If you need parallax together with viewport do Parallax.new and then manually doing parallax.update/draw.
+NOTE: -Doing Parallax.create when using a trait viewport will give bad results.-
+-If you need parallax together with viewport do Parallax.new and then manually doing parallax.update/draw.-
+Now you can use normally the Parallax with viewport.
 
 ==== Trait "collision_detection"
 Adds class and instance methods for basic collision detection.

--- a/README.rdoc
+++ b/README.rdoc
@@ -111,8 +111,8 @@ An "@image = @animation.next" in your Player#update is usually enough to get you
 
 === Chingu::Parallax
 A class for easy parallaxscrolling. Add layers with different damping, move the camera to generate a new snapshot. See example3.rb for more.
-NOTE: Doing Parallax.create when using a trait viewport will give bad results.
-If you need parallax together with viewport do Parallax.new and then manually doing parallax.update/draw.
+
+NOTE: Now the Parallax.create can be used with the trait viewport. Everytime the viewport boundaries change, the Paralax.camera_x/camera_y must be updated too.
 
 === Chingu::HighScoreList
 A class to keep track of high scores, limit the list, automatic sorting on score, save/load to disc. See example13.rb for more.
@@ -757,8 +757,7 @@ This is great for scrolling games. You also have:
   viewport.lag      = 0.95              # Set a lag-factor to use in combination with x_target / y_target
   viewport.x_target = 100               # This will move viewport towards X-coordinate 100, the speed is determined by the lag-parameter.
 
-NOTE: Doing Parallax.create when using a trait viewport will give bad results.
-If you need parallax together with viewport do Parallax.new and then manually doing parallax.update/draw.
+NOTE: Now you can use normally the Parallax with viewport.
 
 ==== Trait "collision_detection"
 Adds class and instance methods for basic collision detection.

--- a/lib/chingu/parallax.rb
+++ b/lib/chingu/parallax.rb
@@ -80,28 +80,28 @@ module Chingu
     # Parallax#camera_x= works in inverse to Parallax#x (moving the "camera", not the image)
     #
     def camera_x=(x)
-      @cx = -x
+      @cx = x
     end
 
     #
     # Parallax#camera_y= works in inverse to Parallax#y (moving the "camera", not the image)
     #
     def camera_y=(y)
-      @cy = -y
+      @cy = y
     end
 
     #
     # Get the x-coordinate for the camera (inverse to x)
     #
     def camera_x
-      -@cx
+      @cx
     end
 
     #
     # Get the y-coordinate for the camera (inverse to y)
     #
     def camera_y
-      -@cy
+      @cy
     end
     
     #
@@ -110,15 +110,15 @@ module Chingu
     def update
       # Viewport data, from GameState parent
       if self.parent.respond_to? :viewport
-	      vpX, vpY = self.camera_x, self.camera_y
+	      vpX, vpY = @cx, @cy
       else
 	      vpX, vpY = 0, 0
       end
   
       @layers.each do |layer|
       	# Get the points which need start to draw
-        layer.x = self.x + (vpX - self.camera_x/layer.damping.to_f).round
-        layer.y = self.y + (vpY - self.camera_y/layer.damping.to_f).round
+        layer.x = self.x + (vpX - @cx/layer.damping.to_f).round
+        layer.y = self.y + (vpY - @cy/layer.damping.to_f).round
 
         # This is the magic that repeats the layer to the left and right
         layer.x -= layer.image.width  while (layer.repeat_x && layer.x > 0)
@@ -132,14 +132,7 @@ module Chingu
     # Draw 
     #
     def draw
-#      # Viewport data, from GameState parent
-#      if  self.parent.respond_to? :viewport
-#      	gaX, gaY, vpW, vpH = self.parent.viewport.game_area
-#      else
-#      	gaX, gaY, vpW, vpH = 0, 0, $window.width, $window.height
-#      end
-#      vpX, vpY = @x, @y
-
+      # Viewport data, from GameState parent
       if  self.parent.respond_to? :viewport
         gaX, gaY, vpW, vpH = self.parent.viewport.game_area
       else
@@ -147,15 +140,16 @@ module Chingu
       end
 
       @layers.each do |layer|
-      	saveX, saveY = layer.x, layer.y
+        save_x, save_y = layer.x, layer.y
+        
         # If layer lands inside our window and repeat_x is true (defaults to true), draw it until window ends
         while layer.repeat_x && layer.x < vpW
           while layer.repeat_y && layer.y < vpH
             layer.draw
             layer.y += layer.image.height
           end
-          layer.y = saveY
-
+          layer.y = save_y
+          
           layer.draw
           layer.x += layer.image.width
         end
@@ -167,7 +161,8 @@ module Chingu
             layer.y += layer.image.height
           end
         end
-        layer.x = saveX
+
+        layer.x = save_x
       end
       self
     end

--- a/lib/chingu/parallax.rb
+++ b/lib/chingu/parallax.rb
@@ -43,6 +43,8 @@ module Chingu
       super(options)
       @repeat_x = options[:repeat_x] || true
       @repeat_y = options[:repeat_y] || false
+      @cx = 0
+      @cy = 0
       
       @layers = Array.new
     end
@@ -78,38 +80,46 @@ module Chingu
     # Parallax#camera_x= works in inverse to Parallax#x (moving the "camera", not the image)
     #
     def camera_x=(x)
-      @x = -x
+      @cx = -x
     end
 
     #
     # Parallax#camera_y= works in inverse to Parallax#y (moving the "camera", not the image)
     #
     def camera_y=(y)
-      @y = -y
+      @cy = -y
     end
 
     #
     # Get the x-coordinate for the camera (inverse to x)
     #
     def camera_x
-      -@x
+      -@cx
     end
 
     #
     # Get the y-coordinate for the camera (inverse to y)
     #
     def camera_y
-      -@y
+      -@cy
     end
     
     #
     # TODO: make use of $window.milliseconds_since_last_update here!
     #
     def update
+      # Viewport data, from GameState parent
+      if self.parent.respond_to? :viewport
+	      vpX, vpY = self.camera_x, self.camera_y
+      else
+	      vpX, vpY = 0, 0
+      end
+  
       @layers.each do |layer|
-        layer.x = @x / layer.damping
-        layer.y = @y / layer.damping
-        
+      	# Get the points which need start to draw
+        layer.x = self.x + (vpX - self.camera_x/layer.damping.to_f).round
+        layer.y = self.y + (vpY - self.camera_y/layer.damping.to_f).round
+
         # This is the magic that repeats the layer to the left and right
         layer.x -= layer.image.width  while (layer.repeat_x && layer.x > 0)
        
@@ -122,30 +132,42 @@ module Chingu
     # Draw 
     #
     def draw
+#      # Viewport data, from GameState parent
+#      if  self.parent.respond_to? :viewport
+#      	gaX, gaY, vpW, vpH = self.parent.viewport.game_area
+#      else
+#      	gaX, gaY, vpW, vpH = 0, 0, $window.width, $window.height
+#      end
+#      vpX, vpY = @x, @y
+
+      if  self.parent.respond_to? :viewport
+        gaX, gaY, vpW, vpH = self.parent.viewport.game_area
+      else
+        gaX, gaY, vpW, vpH = 0, 0, $window.width, $window.height
+      end
+
       @layers.each do |layer|
-        save_x, save_y = layer.x, layer.y
-        
+      	saveX, saveY = layer.x, layer.y
         # If layer lands inside our window and repeat_x is true (defaults to true), draw it until window ends
-        while layer.repeat_x && layer.x < $window.width
-          while layer.repeat_y && layer.y < $window.height
+        while layer.repeat_x && layer.x < vpW
+          while layer.repeat_y && layer.y < vpH
             layer.draw
             layer.y += layer.image.height
           end
-          layer.y = save_y
-          
+          layer.y = saveY
+
           layer.draw
           layer.x += layer.image.width
         end
         
         # Special loop for when repeat_y is true but not repeat_x
         if layer.repeat_y && !layer.repeat_x
-          while layer.repeat_y && layer.y < $window.height
+          while layer.repeat_y && layer.y < vpH
             layer.draw
             layer.y += layer.image.height
           end
         end
-
-        layer.x = save_x
+        layer.x = saveX
       end
       self
     end

--- a/lib/chingu/viewport.rb
+++ b/lib/chingu/viewport.rb
@@ -59,8 +59,8 @@ module Chingu
     # TODO: Add support for x,y here!
     #
     def center_around(object)
-      self.x = object.x * @factor_x - $window.width / 2
-      self.y = object.y * @factor_y - $window.height / 2
+      self.x = object.x * @factor_x - (@width || $window.width) / 2
+      self.y = object.y * @factor_y - (@height || $window.height) / 2
     end
     
     #
@@ -88,8 +88,8 @@ module Chingu
     #
     def inside?(object, y = nil)
       x, y = y ? [object,y] : [object.x, object.y]      
-      x >= @x && x <= (@x + $window.width) &&
-      y >= @y && y <= (@y + $window.height)
+      x >= @x && x <= (@x + (@width || $window.width)) &&
+      y >= @y && y <= (@y + (@height || $window.height))
     end
 
     # Returns true object is outside the view port
@@ -135,7 +135,7 @@ module Chingu
       @x = x
       if @game_area
         @x = @game_area.x * @factor_x         if @x < @game_area.x * @factor_x
-        @x = @game_area.width * @factor_x - $window.width   if @x > @game_area.width * @factor_x - $window.width
+        @x = @game_area.width * @factor_x - (@width || $window.width)   if @x > @game_area.width * @factor_x - (@width || $window.width)
       end
     end
 
@@ -146,8 +146,16 @@ module Chingu
       @y = y
       if @game_area
         @y = @game_area.y * @factor_y           if @y < @game_area.y * @factor_y
-        @y = @game_area.height * @factor_y - $window.height   if @y > @game_area.height * @factor_y - $window.height
+        @y = @game_area.height * @factor_y - (@height || $window.height)   if @y > @game_area.height * @factor_y - (@height || $window.height)
       end
+    end
+
+    def width=(width)
+    	@width = width
+    end
+
+    def height=(width)
+    	@height = height
     end
     
     #


### PR DESCRIPTION
Now the trait `:viewport` and `Parallax` can be used together.
## Without `Viewport`

The example3_parallax.rb default examples works.
## With `Viewport`

``` ruby
class GameStateTest < Chingu::GameState
    traits :timer, :viewport

    def initialize(options)
        super(options)

        self.viewport.lag = 0
        self.viewport.game_area = [0.0, 0.0, 1000.0, 1000.0]

        @parallaxes = []

        tmp = Chingu::Parallax.create(:x => 0, :y => 0, :rotation_center => :top_left, :zorder => 1)
        tmp.add_layer(:image => "grass.png", :damping => 10, :center => 0)
        @parallaxes << tmp

        tmp = Chingu::Parallax.create(:x => 0, :y => 283, :rotation_center => :top_left, :zorder => 2)
        tmp << {:image => "grassfg.png", :y=>100, :damping => 1, :center => 0}
        @parallaxes << tmp

        tmp = Chingu::Parallax.create(:x => 0, :y => tmp.y-30, :rotation_center => :top_left, :zorder => 2)
        tmp << {:image => "grassfg2.png", :y=>-100, :damping => 1, :center => 0}
        @parallaxes << tmp


        @bird = Player.create(:x => 200, :y => 0, :image => "player.png")
    end
    ...
    def update
        self.viewport.center_around(@bird)
        @parallaxes.each do |parallax|
            parallax.camera_x = self.viewport.x
            parallax.camera_y = self.viewport.y
        end
        super
    end
    ...
end
```
