### PR TITLE
Line of sight

### DIFF
--- a/lib/chingu/game_object_map.rb
+++ b/lib/chingu/game_object_map.rb
@@ -190,7 +190,7 @@ module Chingu
     # Yields to the block each GameObject in this map's grid which lies between
     # two GameObjects: origin and dest. 
     #
-    def each_object_between(origin, dest)
+    def each_game_object_between(origin, dest)
       grid_spaces_between(origin, dest) do |x, y|
         obj = game_object_at(x, y)
         yield if obj and obj != origin and obj != dest
@@ -210,9 +210,9 @@ module Chingu
     #
     # This can be used to find line-of-sight between two objects, for example:
     #
-    #   player.sees_enemy if game_object_map.object_between?(player, enemy, :only => Wall) # Walls block vision
+    #   player.sees_enemy if game_object_map.game_object_between?(player, enemy, :only => Wall) # Walls block vision
     #
-    def object_between?(origin, dest, options={})
+    def game_object_between?(origin, dest, options={})
       grid_spaces_between(origin, dest) do |x, y|
         if options[:target]
           x_pixels = x * @grid[0]

--- a/lib/chingu/game_object_map.rb
+++ b/lib/chingu/game_object_map.rb
@@ -207,6 +207,10 @@ module Chingu
     # If options[:only] is set, return true only if the matched object is_a?
     # options[:only].
     #
+    # This can be used to find line-of-sight between two objects, for example:
+    #
+    #   player.sees_enemy if game_object_map.object_between?(player, enemy, :only => Wall) # Walls block vision
+    #
     def object_between?(origin, dest, options={})
       grid_spaces_between(origin, dest) do |x, y|
         if options[:target]

--- a/lib/chingu/game_object_map.rb
+++ b/lib/chingu/game_object_map.rb
@@ -185,6 +185,105 @@ module Chingu
       objects
     end
 
-    
+    #
+    # Yields to the block each GameObject in this map's grid which lies between
+    # two GameObjects: origin and dest. 
+    #
+    def each_object_between(origin, dest)
+      grid_spaces_between(origin, dest) do |x, y|
+        obj = game_object_at(x, y)
+        yield if obj and obj != origin and obj != dest
+      end
+    end
+
+    #
+    # Options can contain the keys :target and :only.
+    #
+    # Returns true if GameObject options[:target] is between GameObjects origin and dest.
+    #
+    # If the target is nil, returns true if any GameObject in this map's grid lies
+    # between origin and dest.
+    #
+    # If options[:only] is set, return true only if the matched object is_a?
+    # options[:only].
+    #
+    def object_between?(origin, dest, options={})
+      grid_spaces_between(origin, dest) do |x, y|
+        if options[:target]
+          x_pixels = x * @grid[0]
+          y_pixels = y * @grid[1]
+          return true if options[:target].collision_at?(x_pixels, y_pixels) 
+        else
+          obj = game_object_at(x, y)
+          if options[:only]
+            return true if obj and obj != origin and obj != dest and obj.is_a? options[:only]
+          else
+            return true if obj and obj != origin and obj != dest
+          end
+        end
+      end
+      return false
+    end
+
+    #
+    # Return the GameObject at the grid coordinates (not pixel coordinates) x and
+    # y. If there is no object there, return nil.
+    #
+    def game_object_at(x, y)
+      return @map[x][y] if @map[x] and @map[x][y]
+      return nil
+    end
+
+    #
+    # Returns an array of [x, y] grid coordinate pairs in this map's grid between
+    # the GameObjects origin and dest. 
+    #
+    # If a block is given, the method will yield x, y to the block for each grid
+    # square.
+    #
+    def grid_spaces_between(origin, dest)
+      # Note: x and y here are a Grid location, not pixel coordinates.
+      raise "Expected GameObject as origin, got #{origin.class}" unless origin.is_a? Chingu::GameObject
+      raise "Expected GameObject as dest, got #{dest.class}" unless dest.is_a? Chingu::GameObject
+      start_x = (origin.bb.x/ @grid[0]).to_i
+      stop_x =  (dest.bb.x/ @grid[0]).to_i
+      start_y = (origin.bb.y/ @grid[1]).to_i
+      stop_y =  (dest.bb.y/ @grid[1]).to_i
+      diff_x = (start_x - stop_x).abs
+      diff_y = (start_y - stop_y).abs
+
+      x = start_x
+      y = start_y
+      n = 1 + diff_x + diff_y
+      x_inc = 1 #FIXME: do fewer checks
+      x_inc = -1 if start_x > stop_x
+      y_inc = 1
+      y_inc = -1 if start_y > stop_y
+      error = diff_x - diff_y
+      diff_x *= 2
+      diff_y *= 2
+
+
+      checked_squares = []
+      checked_squares << [start_x,start_y]
+      checked_squares << [stop_x,stop_y]
+      n.times do
+
+        checked_squares << [x,y]
+        yield(x, y) if block_given?
+
+        if error > 0
+          x += x_inc
+          error -= diff_y
+        else
+          y += y_inc
+          error += diff_x
+        end
+
+      end
+
+      return checked_squares
+    end
+
   end
 end

--- a/lib/chingu/game_object_map.rb
+++ b/lib/chingu/game_object_map.rb
@@ -164,6 +164,27 @@ module Chingu
         end
       end
     end
+
+    #
+    # Returns an array of GameObjects in this grid map that collide with the given
+    # GameObject (which is not on the grid). 
+    #
+    def collisions_with(game_object)
+      start_x = (game_object.bb.left / @grid[0]).to_i
+      stop_x =  (game_object.bb.right / @grid[0]).to_i
+
+      objects = []
+      (start_x ... stop_x).each do |x|
+        start_y = (game_object.bb.top / @grid[1]).to_i
+        stop_y =  (game_object.bb.bottom / @grid[1]).to_i
+
+        (start_y ... stop_y).each do |y|
+          objects << @map[x][y] if @map[x] && @map[x][y] && @map[x][y] != game_object  # Don't yield collisions with itself
+        end
+      end
+      objects
+    end
+
     
   end
 end

--- a/lib/chingu/game_object_map.rb
+++ b/lib/chingu/game_object_map.rb
@@ -179,7 +179,8 @@ module Chingu
         stop_y =  (game_object.bb.bottom / @grid[1]).to_i
 
         (start_y ... stop_y).each do |y|
-          objects << @map[x][y] if @map[x] && @map[x][y] && @map[x][y] != game_object  # Don't yield collisions with itself
+          obj = game_object_at(x, y)
+          objects << @map[x][y] if obj and obj != game_object  # Don't yield collisions with itself
         end
       end
       objects

--- a/lib/chingu/helpers/game_object.rb
+++ b/lib/chingu/helpers/game_object.rb
@@ -73,8 +73,9 @@ module Chingu
                 object = klass.create(attributes)
                 object.options[:created_with_editor] = true if object.options
               end
-            rescue
-              puts "Couldn't create class '#{klassname}'"
+            rescue => e
+              puts "Couldn't create class '#{klassname}' because: #{e}"
+              raise
             end
           end
         end

--- a/lib/chingu/helpers/game_object.rb
+++ b/lib/chingu/helpers/game_object.rb
@@ -75,7 +75,7 @@ module Chingu
               end
             rescue => e
               puts "Couldn't create class '#{klassname}' because: #{e}"
-              raise
+              #raise # I suggest this re-raise the error.
             end
           end
         end

--- a/spec/chingu/game_object_map_spec.rb
+++ b/spec/chingu/game_object_map_spec.rb
@@ -34,6 +34,8 @@ module Chingu
       MyBigGameObject.destroy_all
       @game_object = MyGameObject.create
       @big_game_object = MyBigGameObject.create
+
+      @grid_size = [20,20]
     end
 
     after :each do
@@ -52,7 +54,7 @@ module Chingu
 
     context "containing a game object size 20x20 postion 0,0" do
       before :each do
-        @game_object_map = GameObjectMap.new(:game_objects => MyGameObject.all, :grid => [20,20])
+        @game_object_map = GameObjectMap.new(:game_objects => MyGameObject.all, :grid => @grid_size)
       end
       
       it "should be found at 0,0" do
@@ -74,7 +76,7 @@ module Chingu
 
     context "containing a game object size 40x40 postion 0,0" do
       before :each do
-        @game_object_map = GameObjectMap.new(:game_objects => MyBigGameObject.all, :grid => [20,20])
+        @game_object_map = GameObjectMap.new(:game_objects => MyBigGameObject.all, :grid => @grid_size)
       end
       
       it "should be found at 0,0" do
@@ -91,6 +93,60 @@ module Chingu
         @game_object_map.at(40,40).should == nil
       end
 
+    end
+
+    context "containing game objects size 20x20 at position 100,100 and 1,1" do
+      before :each do
+        @other_game_object = MyGameObject.create
+        @other_game_object.x = @other_game_object.y = 1
+        @game_object.x = @game_object.y = 100
+        @game_object_map = GameObjectMap.new(:game_objects => MyGameObject.all, :grid => @grid_size)
+      end
+
+      context "when a player game object is at 50,100" do
+        before :each do
+          @player = MyGameObject.create
+          @player.x, @player.y = 50, 100
+        end
+
+        context "and a dest game object is at 80, 100" do
+          before :each do
+            @dest = MyGameObject.create
+            @dest.x, @dest.y = 80, 100
+          end
+
+          it "game_object_between? returns false" do
+            @game_object_map.game_object_between?(@player, @dest).should_not be true
+          end
+        end
+
+        context "and a dest game object is at 150, 100" do
+          before :each do
+            @dest = MyGameObject.create
+            @dest.x, @dest.y = 150, 100
+          end
+
+          it "game_object_between? returns true" do
+            @game_object_map.game_object_between?(@player, @dest).should be true
+          end
+
+          it "game_object_between? with target: the grid object between player and dest returns true" do
+            @game_object_map.game_object_between?(@player, @dest, target: @game_object).should be true
+          end
+
+          it "game_object_between? with target: the grid object at 1,1 returns false" do
+            @game_object_map.game_object_between?(@player, @dest, target: @other_game_object).should_not be true
+          end
+
+          it "game_object_between? with only: the game object class of the grid object returns false" do
+            @game_object_map.game_object_between?(@player, @dest, only: @game_object.class).should be true
+          end
+
+          it "game_object_between? with only: a different game object returns false" do
+            @game_object_map.game_object_between?(@player, @dest, only: @big_game_object.class).should_not be true
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add methods to GameObjectMap to find line-of-sight between objects. Specifically: #collisions_with, #each_game_object_between, #game_object_between?, #game_object_at, and #grid_spaces_between.

Here's an example of its use: 

```
player.sees_enemy if game_object_map.game_object_between?(player, enemy, :only => Wall) # Walls block vision
```

Also another small change to GameObject#load_game_objects to specify the exception that caused the error. I have a further (commented-out) suggestion to re-raise such errors, but that is outside the scope of this branch.
