### PR TITLE
Make Chingu::Animation#[] accept Enumerables instead of just Ranges

### DIFF
--- a/lib/chingu/animation.rb
+++ b/lib/chingu/animation.rb
@@ -174,7 +174,7 @@ module Chingu
     #
     def [](index)
       return @frames[index]               if  index.is_a?(Fixnum)
-      return self.new_from_frames(index)  if  index.is_a?(Range)
+      return self.new_from_frames(index)  if  index.respond_to?(:each)
       return @sub_animations[index]       if  index.is_a?(Symbol)
     end
 


### PR DESCRIPTION
This way it's easy to extract a subanimation from non-consecutive, frames,
like this:

```
@animation[(1..10).step(2)]
```
