### PR TITLE
Update game_state_manager.rb

### DIFF
--- a/lib/chingu/game_state_manager.rb
+++ b/lib/chingu/game_state_manager.rb
@@ -131,6 +131,7 @@ module Chingu
                 
         # Give the soon-to-be-disabled state a chance to clean up by calling finalize() on it.
         current_game_state.finalize   if current_game_state.respond_to?(:finalize) && options[:finalize]
+        new_state.previous_game_state = current_game_state
         
         if @transitional_game_state && options[:transitional]
           # If we have a transitional, push that instead, with new_state as first argument

--- a/lib/chingu/helpers/gfx.rb
+++ b/lib/chingu/helpers/gfx.rb
@@ -185,7 +185,7 @@ module Chingu
       $window.draw_line(left,  top,    color_a, left,  bottom, color_b, zorder, mode)
       $window.draw_line(left,  bottom, color_b, right, bottom, color_c, zorder, mode)
       $window.draw_line(right, bottom, color_c, right, top,    color_d, zorder, mode)
-      $window.draw_line(right, top,    color_d, left,  top,    color_a, zorder, mode)
+      $window.draw_line(right + 1, top,    color_d, left,  top,    color_a, zorder, mode) # make a COMPLETE rectangle
     end
     
     #


### PR DESCRIPTION
Made previous_game_state work again!
Added a line to allow things that use previous_game_state to work again.
This is useful for game menus, where you don't want to erase the previous screen, but instead draw over it.
